### PR TITLE
Dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ Cargo.lock
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
 .env
+.vscode/

--- a/src/vars.rs
+++ b/src/vars.rs
@@ -1,10 +1,12 @@
 use std::{any::type_name, env, fmt::Debug, str::FromStr};
 
-pub const DISCORD_BOT_APPLICATION_ID: &str = "DISCORD_APPLICATION_ID";
+pub const DISCORD_BOT_APPLICATION_ID: &str = "DISCORD_BOT_APPLICATION_ID";
 pub const DISCORD_BOT_TOKEN: &str = "DISCORD_BOT_TOKEN";
 pub const DISCORD_BOT_AUDIO_DIR: &str = "DISCORD_BOT_AUDIO_DIR";
 pub const DISCORD_BOT_DOTENV_FILE: &str = "DISCORD_BOT_DOTENV_FILE";
 pub const DISCORD_BOT_COMMAND_PREFIX: &str = "DISCORD_BOT_COMMAND_PREFIX";
+pub const DISCORD_BOT_JOIN_AUDIO: &str = "DISCORD_BOT_JOIN_AUDIO";
+pub const DISCORD_BOT_LEAVE_AUDIO: &str = "DISCORD_BOT_LEAVE_AUDIO";
 
 /// Simple wrapper to get env vars and use default values on some env variables
 pub fn get<'a, T>(name: impl Into<&'a str>) -> T
@@ -21,6 +23,8 @@ where
         DISCORD_BOT_AUDIO_DIR => env::var(name).unwrap_or("./audio".into()),
         DISCORD_BOT_COMMAND_PREFIX => env::var(name).unwrap_or("sb:".into()),
         DISCORD_BOT_DOTENV_FILE => env::var(name).unwrap_or(".env".into()),
+        DISCORD_BOT_JOIN_AUDIO => env::var(name).unwrap_or("".into()), //default disabled
+        DISCORD_BOT_LEAVE_AUDIO => env::var(name).unwrap_or("".into()), //default disabled
         _ => env::var(name).expect(expect_msg),
     };
 

--- a/src/vars.rs
+++ b/src/vars.rs
@@ -1,0 +1,34 @@
+use std::{any::type_name, env, fmt::Debug, str::FromStr};
+
+pub const DISCORD_BOT_APPLICATION_ID: &str = "DISCORD_APPLICATION_ID";
+pub const DISCORD_BOT_TOKEN: &str = "DISCORD_BOT_TOKEN";
+pub const DISCORD_BOT_AUDIO_DIR: &str = "DISCORD_BOT_AUDIO_DIR";
+pub const DISCORD_BOT_DOTENV_FILE: &str = "DISCORD_BOT_DOTENV_FILE";
+pub const DISCORD_BOT_COMMAND_PREFIX: &str = "DISCORD_BOT_COMMAND_PREFIX";
+
+/// Simple wrapper to get env vars and use default values on some env variables
+pub fn get<'a, T>(name: impl Into<&'a str>) -> T
+where
+    T: FromStr,
+    <T as FromStr>::Err: std::fmt::Debug,
+{
+    let name = name.into();
+
+    let expect_msg = format!("Missing {name} environment variable value");
+    let expect_msg = expect_msg.as_str();
+
+    let val = match name {
+        DISCORD_BOT_AUDIO_DIR => env::var(name).unwrap_or("./audio".into()),
+        DISCORD_BOT_COMMAND_PREFIX => env::var(name).unwrap_or("sb:".into()),
+        DISCORD_BOT_DOTENV_FILE => env::var(name).unwrap_or(".env".into()),
+        _ => env::var(name).expect(expect_msg),
+    };
+
+    val.parse::<T>().expect(
+        format!(
+            "Failed to parse env var {name} to type {}",
+            type_name::<T>()
+        )
+        .as_str(),
+    )
+}


### PR DESCRIPTION
# Embedded Sound Buttons 

Using the `sb:sounds` command in a text channel will produce a grid of buttons that can be pressed to produce sounds by the sound bot. 

**note***:  The embedded button grid (i.e. Action Rows) has a [5x5 limitation](https://discordjs.guide/message-components/action-rows.html#action-rows)

# Join/Leave Bot Audio

- `DISCORD_BOT_JOIN_AUDIO` - default disabled. Set to audio track name in audio directory to play audio when bot joins voice channel. 
- `DISCORD_BOT_LEAVE_AUDIO` - default disabled. Set to audio track name in audio directory to play audio when bot leaves voice channel.