### PR TITLE
File watch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3034,7 +3034,7 @@ dependencies = [
 
 [[package]]
 name = "soundboard-bot"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soundboard-bot"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -348,6 +348,7 @@ pub async fn display_sounds(
                 &mut paginator,
                 helpers::DisplayType::Search,
                 Some(search.clone()),
+                ctx.data().config.enable_ephemeral_controls,
             )?;
 
             ctx.send(reply_msg.into())
@@ -360,8 +361,12 @@ pub async fn display_sounds(
                     .page_limit(ctx.data().config.max_page_size)
                     .build();
 
-            let reply_msg =
-                helpers::make_display_message(&mut paginator, helpers::DisplayType::All, None)?;
+            let reply_msg = helpers::make_display_message(
+                &mut paginator,
+                helpers::DisplayType::All,
+                None,
+                ctx.data().config.enable_ephemeral_controls,
+            )?;
 
             ctx.send(reply_msg.into())
                 .await
@@ -369,9 +374,11 @@ pub async fn display_sounds(
         }
     }
 
-    ctx.send(helpers::make_sound_controls_message().into())
-        .await
-        .log_err_msg(format!("`/sounds display` failed sending sound controls"))?;
+    ctx.send(
+        helpers::make_sound_controls_message(ctx.data().config.enable_ephemeral_controls).into(),
+    )
+    .await
+    .log_err_msg(format!("`/sounds display` failed sending sound controls"))?;
 
     Ok(())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,8 @@ pub struct Config {
     pub max_audio_file_duration: std::time::Duration,
     #[serde(default = "default_max_page_size")]
     pub max_page_size: u64,
+    #[serde(default = "default_enable_ephemeral_controls")]
+    pub enable_ephemeral_controls: bool,
 }
 
 impl Config {
@@ -81,8 +83,13 @@ impl Default for Config {
             sqlite_db_file: default_sqlite_db_file(),
             max_audio_file_duration: default_max_audio_file_duration(),
             max_page_size: default_max_page_size(),
+            enable_ephemeral_controls: default_enable_ephemeral_controls(),
         }
     }
+}
+
+fn default_enable_ephemeral_controls() -> bool {
+    true
 }
 
 fn default_max_page_size() -> u64 {

--- a/src/db/audio_table.rs
+++ b/src/db/audio_table.rs
@@ -622,7 +622,7 @@ impl AudioTableOrderBy {
         match self {
             Self::CreatedAt(order) => format!("created_at {order}"),
             Self::Id(order) => format!("id {order}"),
-            Self::Name(order) => format!("name {order}"),
+            Self::Name(order) => format!("name COLLATE NOCASE {order}"),
             Self::PlayCount(order) => format!("play_count {order}"),
         }
     }

--- a/src/db/audio_table.rs
+++ b/src/db/audio_table.rs
@@ -522,6 +522,35 @@ impl Table for AudioTable {
         &self.conn
     }
 
+    fn drop_table(&self) {
+        let table_name = Self::TABLE_NAME;
+        let fts5_table_name = Self::FTS5_TABLE_NAME;
+
+        log::info!("Dropping tables {table_name}, {fts5_table_name}...");
+
+        let sql = format!(
+            "
+            BEGIN;
+                DROP TABLE IF EXISTS {table_name};
+
+                DROP TABLE IF EXISTS {fts5_table_name};
+
+                DROP TRIGGER IF EXISTS {table_name}_insert;
+
+                DROP TRIGGER IF EXISTS {table_name}_delete;
+
+                DROP TRIGGER IF EXISTS {table_name}_update;
+            COMMIT;"
+        );
+
+        self.conn
+            .execute_batch(sql.as_str())
+            .log_err_msg(format!("Failed creating table:{table_name}"))
+            .unwrap();
+
+        log::info!("Created tables {table_name}, {fts5_table_name}!");
+    }
+
     fn create_table(&self) {
         let table_name = Self::TABLE_NAME;
         let fts5_table_name = Self::FTS5_TABLE_NAME;

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -13,6 +13,8 @@ pub type DbConnection = r2d2::PooledConnection<r2d2_sqlite::SqliteConnectionMana
 pub trait Table {
     fn connection(&self) -> &DbConnection;
     fn create_table(&self);
+    #[allow(unused)]
+    fn drop_table(&self);
 }
 
 #[derive(Debug)]

--- a/src/db/paginators.rs
+++ b/src/db/paginators.rs
@@ -31,12 +31,10 @@ pub struct PaginateInfo {
 
 impl AudioTablePaginator {
     pub fn pageinate_info(&self) -> Result<PaginateInfo, String> {
-        let round_fn = |num: f64| (num + 0.5f64).floor();
         let row_count = self.row_count()?;
-
-        let total_pages = round_fn(row_count as f64 / self.page_limit as f64) as u64;
+        let total_pages = (row_count as f64 / self.page_limit as f64).ceil() as u64;
         let cur_page = if row_count > 0 {
-            (self.offset / self.page_limit) + 1
+            ((self.offset + 1) as f64 / self.page_limit as f64).ceil() as u64
         } else {
             0
         };
@@ -47,10 +45,10 @@ impl AudioTablePaginator {
             Some(0)
         };
 
-        let last_page_offset = if total_pages == 0 || cur_page == total_pages || row_count == 0 {
-            None
-        } else {
+        let last_page_offset = if total_pages > 1 && cur_page < total_pages {
             Some((total_pages - 1) * self.page_limit)
+        } else {
+            None
         };
 
         let prev_page_offset = if (self.offset as i64 - self.page_limit as i64) < 0 {
@@ -399,7 +397,7 @@ mod tests {
                 .unwrap();
         }
 
-        let mut paginator = AudioTablePaginator::builder(db_pool.get().unwrap())
+        let mut paginator = AudioTablePaginatorBuilder::new(db_pool.get().unwrap())
             .page_limit(2)
             .build();
 
@@ -430,7 +428,7 @@ mod tests {
 
         // Test pagination with limit
         {
-            let mut paginator = AudioTablePaginator::builder(db_pool.get().unwrap())
+            let mut paginator = AudioTablePaginatorBuilder::new(db_pool.get().unwrap())
                 .page_limit(1)
                 .limit(Some(2))
                 .build();
@@ -449,7 +447,7 @@ mod tests {
 
         // Test pagination page_limit exceeds total limit
         {
-            let mut paginator = AudioTablePaginator::builder(db_pool.get().unwrap())
+            let mut paginator = AudioTablePaginatorBuilder::new(db_pool.get().unwrap())
                 .page_limit(5)
                 .limit(Some(3))
                 .build();
@@ -492,7 +490,7 @@ mod tests {
 
         // plain fts filter
         {
-            let mut paginator = AudioTablePaginator::builder(db_pool.get().unwrap())
+            let mut paginator = AudioTablePaginatorBuilder::new(db_pool.get().unwrap())
                 .page_limit(2)
                 .fts_filter(Some("star".into()))
                 .build();
@@ -510,7 +508,7 @@ mod tests {
 
         // fts edge case
         {
-            let mut paginator = AudioTablePaginator::builder(db_pool.get().unwrap())
+            let mut paginator = AudioTablePaginatorBuilder::new(db_pool.get().unwrap())
                 .fts_filter(Some("asdfasdfasdfasdf".into()))
                 .build();
 
@@ -519,7 +517,7 @@ mod tests {
             let page = paginator.next();
             assert!(page.is_none());
 
-            paginator = AudioTablePaginator::builder(db_pool.get().unwrap())
+            paginator = AudioTablePaginatorBuilder::new(db_pool.get().unwrap())
                 .fts_filter(Some("@''\"''\"@#$%^&*()!".into()))
                 .build();
 
@@ -562,7 +560,7 @@ mod tests {
         row.tags = "tag1".into();
         table.insert_audio_row(row).unwrap();
 
-        let mut paginator = AudioTablePaginator::builder(db_pool.get().unwrap())
+        let mut paginator = AudioTablePaginatorBuilder::new(db_pool.get().unwrap())
             .fts_filter(Some("tag1".into()))
             .page_limit(1)
             .offset(2)
@@ -576,5 +574,115 @@ mod tests {
 
         let page = paginator.next();
         assert!(page.is_none());
+    }
+
+    #[test]
+    fn paginate_info_test() {
+        let db_manager = SqliteConnectionManager::memory();
+        let db_pool = r2d2::Pool::new(db_manager).unwrap();
+        let table = AudioTable::new(db_pool.get().unwrap());
+
+        // test paginate info
+        {
+            let page_limit = 3;
+            let target_row_count = (page_limit * 9) + 1;
+            table.create_table();
+
+            for _ in 0..target_row_count {
+                table
+                    .insert_audio_row(make_audio_table_row_insert())
+                    .unwrap();
+            }
+
+            let paginator = AudioTablePaginatorBuilder::new(db_pool.get().unwrap())
+                .page_limit(page_limit)
+                .build();
+
+            let info = paginator.pageinate_info().unwrap();
+
+            assert_eq!(info.page_limit, page_limit);
+            assert_eq!(info.total_row_count, target_row_count);
+            assert_eq!(info.total_pages, 10);
+            assert_eq!(info.first_page_offset, None);
+            assert_eq!(info.prev_page_offset, None);
+            assert_eq!(info.next_page_offset, Some(page_limit));
+            assert_eq!(info.last_page_offset, Some(9 * page_limit));
+            assert_eq!(info.cur_page, 1);
+
+            let paginator = AudioTablePaginatorBuilder::new(db_pool.get().unwrap())
+                .page_limit(page_limit)
+                .offset(6)
+                .build();
+
+            let info = paginator.pageinate_info().unwrap();
+
+            assert_eq!(info.page_limit, page_limit);
+            assert_eq!(info.total_row_count, target_row_count);
+            assert_eq!(info.total_pages, 10);
+            assert_eq!(info.first_page_offset, Some(0));
+            assert_eq!(info.prev_page_offset, Some(3));
+            assert_eq!(info.next_page_offset, Some(9));
+            assert_eq!(info.last_page_offset, Some(9 * page_limit));
+            assert_eq!(info.cur_page, 3);
+
+            let paginator = AudioTablePaginatorBuilder::new(db_pool.get().unwrap())
+                .page_limit(page_limit)
+                .offset(9 * page_limit)
+                .build();
+
+            let info = paginator.pageinate_info().unwrap();
+
+            assert_eq!(info.page_limit, page_limit);
+            assert_eq!(info.total_row_count, target_row_count);
+            assert_eq!(info.total_pages, 10);
+            assert_eq!(info.first_page_offset, Some(0));
+            assert_eq!(info.prev_page_offset, Some(24));
+            assert_eq!(info.next_page_offset, None);
+            assert_eq!(info.last_page_offset, None);
+            assert_eq!(info.cur_page, 10);
+        }
+
+        // test paginate info edge cases
+        {
+            table.drop_table();
+            table.create_table();
+
+            let page_limit = 3;
+            let paginator = AudioTablePaginatorBuilder::new(db_pool.get().unwrap())
+                .page_limit(page_limit)
+                .build();
+
+            let info = paginator.pageinate_info().unwrap();
+
+            assert_eq!(info.page_limit, page_limit);
+            assert_eq!(info.total_row_count, 0);
+            assert_eq!(info.total_pages, 0);
+            assert_eq!(info.first_page_offset, None);
+            assert_eq!(info.prev_page_offset, None);
+            assert_eq!(info.next_page_offset, None);
+            assert_eq!(info.last_page_offset, None);
+            assert_eq!(info.cur_page, 0);
+
+            for _ in 0..3 {
+                table
+                    .insert_audio_row(make_audio_table_row_insert())
+                    .unwrap();
+            }
+
+            let paginator = AudioTablePaginatorBuilder::new(db_pool.get().unwrap())
+                .page_limit(page_limit)
+                .build();
+
+            let info = paginator.pageinate_info().unwrap();
+
+            assert_eq!(info.page_limit, page_limit);
+            assert_eq!(info.total_row_count, 3);
+            assert_eq!(info.total_pages, 1);
+            assert_eq!(info.first_page_offset, None);
+            assert_eq!(info.prev_page_offset, None);
+            assert_eq!(info.next_page_offset, None);
+            assert_eq!(info.last_page_offset, None);
+            assert_eq!(info.cur_page, 1);
+        }
     }
 }

--- a/src/db/settings_table.rs
+++ b/src/db/settings_table.rs
@@ -104,6 +104,26 @@ impl Table for SettingsTable {
         &self.conn
     }
 
+    fn drop_table(&self) {
+        let table_name = Self::TABLE_NAME;
+        log::info!("Dropping table: {table_name}");
+        let sql = format!(
+            "
+            DROP TABLE IF EXISTS {table_name} (
+                id INTEGER PRIMARY KEY,
+                join_audio VARCHAR(80),
+                leave_audio VARCHAR(80)
+            );
+        "
+        );
+
+        self.conn
+            .execute_batch(sql.as_str())
+            .log_err_msg("Failed dropping table")
+            .log_ok_msg(format!("Dropped table {table_name}"))
+            .unwrap();
+    }
+
     fn create_table(&self) {
         let table_name = Self::TABLE_NAME;
         log::info!("Creating table: {table_name}");


### PR DESCRIPTION
- Adds file watch to detect messages with attached MP3 file
  - Messages with an attached MP3 file have soundbot buttons provided to either add the sound or ignore the sound.
- Sound bot controls are now "ephemeral" so that they are only visible to the individual users
  - This cuts down on message bloat in a text channel
  - Users will not be able to interfere with one another's pagination controls
- Adds the ability to drop tables
  - This is mostly for unit tests but is useful enough to keep as a whole